### PR TITLE
chore(caniuse-lite): upgrade caniuse-lite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -300,12 +300,6 @@
             "node-releases": "^1.1.75"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001252",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
-          "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
-          "dev": true
-        },
         "colorette": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
@@ -3589,12 +3583,6 @@
             "escalade": "^3.1.1",
             "node-releases": "^1.1.75"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001252",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
-          "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
-          "dev": true
         },
         "colorette": {
           "version": "1.3.0",
@@ -18264,12 +18252,6 @@
             "node-releases": "^1.1.75"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001252",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
-          "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
-          "dev": true
-        },
         "colorette": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
@@ -19106,9 +19088,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001220",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001220.tgz",
-      "integrity": "sha512-pjC2T4DIDyGAKTL4dMvGUQaMUHRmhvPpAgNNTa14jaBWHu+bLQgvpFqElxh9L4829Fdx0PlKiMp3wnYldRtECA=="
+      "version": "1.0.30001282",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz",
+      "integrity": "sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg=="
     },
     "capital-case": {
       "version": "1.0.4",
@@ -30753,11 +30735,6 @@
             "escalade": "^3.1.1",
             "node-releases": "^1.1.71"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001274",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001274.tgz",
-          "integrity": "sha512-+Nkvv0fHyhISkiMIjnyjmf5YJcQ1IQHZN6U9TLUMroWR38FNwpsC51Gb68yueafX1V6ifOisInSgP9WJFS13ew=="
         },
         "nanoid": {
           "version": "3.1.30",


### PR DESCRIPTION
npx browserslist@latest --update-db
npx: installed 6 in 1.798s
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
Latest version:     1.0.30001282
Installed versions: 1.0.30001220, 1.0.30001252, 1.0.30001274
Removing old caniuse-lite from lock file
Installing new caniuse-lite version

...

caniuse-lite has been successfully updated

Target browser changes:

```diff
- and_chr 90
+ and_chr 95
- and_ff 87
+ and_ff 92
- android 90
+ android 95
- chrome 90
- chrome 89
- chrome 88
- chrome 87
+ chrome 96
+ chrome 95
+ chrome 94
+ chrome 93
+ chrome 92
- edge 90
- edge 89
- edge 88
+ edge 95
+ edge 94
- firefox 88
- firefox 87
- firefox 86
+ firefox 94
+ firefox 93
+ firefox 92
- ios_saf 14.5
- ios_saf 13.4-13.7
+ ios_saf 15
+ ios_saf 14.5-14.8
+ ios_saf 12.2-12.5
- op_mob 62
+ op_mob 64
- opera 75
- opera 74
+ opera 81
+ opera 80
+ opera 79
- safari 14
+ safari 15.1
+ safari 15
- samsung 13.0
+ samsung 15.0
```